### PR TITLE
Feature/gpsr recognition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_service_files(
   ListClasses.srv
   PeopleIntroducing.srv
   LookAtDescription3D.srv
+  SetClass.srv
+  VisualQuestionAnswering.srv
 )
 
 generate_messages(

--- a/msg/Recognitions2D.msg
+++ b/msg/Recognitions2D.msg
@@ -2,6 +2,7 @@ std_msgs/Header header
 
 Description2D[] descriptions
 
+sensor_msgs/Image image_set_of_marks
 sensor_msgs/Image image_rgb #image in which 2D descriptions where observed (optional)
 sensor_msgs/Image image_depth #depth image to possibly pass from Description to Description3D (needs camera_info too) (optional)
 sensor_msgs/CameraInfo camera_info #camera info to transform from Description to Description3D (needs image_depth too) (optional)

--- a/msg/Recognitions3D.msg
+++ b/msg/Recognitions3D.msg
@@ -3,3 +3,4 @@ std_msgs/Header header
 Description3D[] descriptions
 
 sensor_msgs/Image image_rgb
+sensor_msgs/Image image_set_of_marks

--- a/srv/SetClass.srv
+++ b/srv/SetClass.srv
@@ -1,0 +1,5 @@
+string class_name
+float64 confidence
+bool detect_best_only
+---
+std_msgs/Empty empty

--- a/srv/VisualQuestionAnswering.srv
+++ b/srv/VisualQuestionAnswering.srv
@@ -1,0 +1,4 @@
+string question
+---
+string answer
+float64 confidence


### PR DESCRIPTION
Backward compatible updates to `butia-vision_msgs`, required for `gpsr-recognition` and `vlm-recognition` branchs of `butia_recognition` to work.